### PR TITLE
fix ignored -n param (max_related)

### DIFF
--- a/word_sense_induction.py
+++ b/word_sense_induction.py
@@ -67,6 +67,7 @@ def ego_network_clustering(neighbors_fpath, clusters_fpath, max_related=300, num
     global G
     global n
     G = CRSGraph(neighbors_fpath)
+    n = max_related
     
     with codecs.open(clusters_fpath, "w", "utf-8") as output, Pool(num_cores) as pool:
         output.write("word\tcid\tcluster\tisas\n")


### PR DESCRIPTION
the code currently ignores the `-n` param. It looks like it was intended to se the global `n` var in `word_sense_induction.py` to this value, but was accidentally left out. This PR fixes this.

closes #35 